### PR TITLE
Dev handle blank sf

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -30,7 +30,7 @@ sed 's/\.\///g' | sed -e 's/^/\/data\//' | paste -sd, -)
 # slightly reformat the STAR-Fusion predicted fusions for Docker
 sr_predictions_name=$(find /home/dnanexus/in/sr_predictions -type f -printf "%f\n")
 cut -f 1 /home/dnanexus/in/sr_predictions/"${sr_predictions_name}" \
-| grep -v '#FusionName' > /home/dnanexus/in/sr_predictions/predicted_fusions.txt
+| grep -v '#FusionName' > /home/dnanexus/predicted_fusions.txt
 
 # Get FusionInspector Docker image by its ID
 docker load -i /home/dnanexus/in/fi_docker/*.tar.gz
@@ -135,7 +135,7 @@ wd="$(pwd)"
 fusion_ins="docker run -v ${wd}:/data --rm \
        ${DOCKER_IMAGE_ID} \
        FusionInspector \
-       --fusions ${known_fusions},/data/in/sr_predictions/predicted_fusions.txt \
+       --fusions ${known_fusions},/data/predicted_fusions.txt \
        -O /data/temp_out \
        --CPU ${NUMBER_THREADS} \
        --left_fq ${read_1} \

--- a/src/code.sh
+++ b/src/code.sh
@@ -29,17 +29,9 @@ sed 's/\.\///g' | sed -e 's/^/\/data\//' | paste -sd, -)
 known_fusions=$(find ./known_fusions/ -type f -name "*" | \
 sed 's/\.\///g' | sed -e 's/^/\/data\//' | paste -sd, -)
 
-# slightly reformat the STAR-Fusion predicted fusions for Docker
+# remove header line from STAR-Fusion predicted fusions for Docker
 sr_predictions_name=$(find /home/dnanexus/sr_predictions -type f -printf "%f\n")
-cut_out=$(cut -f 1 /home/dnanexus/sr_predictions/"${sr_predictions_name}")
-if grep -v '#FusionName' "$cut_out"
-then 
-       grep -v '#FusionName' "$cut_out" > /home/dnanexus/sr_predictions/predicted_fusions.txt
-       fusions_arg="${known_fusions},/data/sr_predictions/predicted_fusions.txt"
-else
-       fusions_arg="${known_fusions}"
-fi
-
+cut -f 1 /home/dnanexus/sr_predictions/"${sr_predictions_name}" > /home/dnanexus/sr_predictions/predicted_fusions.txt
 
 # Get FusionInspector Docker image by its ID
 docker load -i /home/dnanexus/in/fi_docker/*.tar.gz
@@ -144,7 +136,7 @@ wd="$(pwd)"
 fusion_ins="docker run -v ${wd}:/data --rm \
        ${DOCKER_IMAGE_ID} \
        FusionInspector \
-       --fusions ${fusions_arg} \
+       --fusions "${known_fusions},/data/sr_predictions/predicted_fusions.txt" \
        -O /data/temp_out \
        --CPU ${NUMBER_THREADS} \
        --left_fq ${read_1} \

--- a/src/code.sh
+++ b/src/code.sh
@@ -31,7 +31,6 @@ sed 's/\.\///g' | sed -e 's/^/\/data\//' | paste -sd, -)
 
 # remove header line from STAR-Fusion predicted fusions for Docker
 sr_predictions_name=$(find /home/dnanexus/sr_predictions -type f -printf "%f\n")
-cut -f 1 /home/dnanexus/sr_predictions/"${sr_predictions_name}" > /home/dnanexus/sr_predictions/predicted_fusions.txt
 
 # Get FusionInspector Docker image by its ID
 docker load -i /home/dnanexus/in/fi_docker/*.tar.gz
@@ -136,7 +135,7 @@ wd="$(pwd)"
 fusion_ins="docker run -v ${wd}:/data --rm \
        ${DOCKER_IMAGE_ID} \
        FusionInspector \
-       --fusions "${known_fusions},/data/sr_predictions/predicted_fusions.txt" \
+       --fusions "${known_fusions},/data/sr_predictions/${sr_predictions_name}" \
        -O /data/temp_out \
        --CPU ${NUMBER_THREADS} \
        --left_fq ${read_1} \

--- a/src/code.sh
+++ b/src/code.sh
@@ -14,10 +14,12 @@ lib_dir=$(find . -type d -name "*CTAT_lib*")
 mkdir /home/dnanexus/r1_fastqs
 mkdir /home/dnanexus/r2_fastqs
 mkdir /home/dnanexus/known_fusions
+mkdir /home/dnanexus/sr_predictions
 
 find ./in/r1_fastqs -type f -name "*R1*" -print0 | xargs -0 -I {} mv {} ./r1_fastqs
 find ./in/r2_fastqs -type f -name "*R2*" -print0 | xargs -0 -I {} mv {} ./r2_fastqs
 find ./in/known_fusions -type f -name "*.txt*" -print0 | xargs -0 -I {} mv {} ./known_fusions
+find ./in/sr_predictions -type f -print0 | xargs -0 -I {} mv {} ./sr_predictions
 
 # form array:file uploads in a comma-separated list - prepend '/data/' path, for use in Docker
 read_1=$(find ./r1_fastqs/ -type f -name "*" -name "*R1*.f*" | \
@@ -28,9 +30,16 @@ known_fusions=$(find ./known_fusions/ -type f -name "*" | \
 sed 's/\.\///g' | sed -e 's/^/\/data\//' | paste -sd, -)
 
 # slightly reformat the STAR-Fusion predicted fusions for Docker
-sr_predictions_name=$(find /home/dnanexus/in/sr_predictions -type f -printf "%f\n")
-cut -f 1 /home/dnanexus/in/sr_predictions/"${sr_predictions_name}" \
-| grep -v '#FusionName' > /home/dnanexus/predicted_fusions.txt
+sr_predictions_name=$(find /home/dnanexus/sr_predictions -type f -printf "%f\n")
+cut_out=$(cut -f 1 /home/dnanexus/sr_predictions/"${sr_predictions_name}")
+if grep -v '#FusionName' "$cut_out"
+then 
+       grep -v '#FusionName' "$cut_out" > /home/dnanexus/sr_predictions/predicted_fusions.txt
+       fusions_arg="${known_fusions},/data/sr_predictions/predicted_fusions.txt"
+else
+       fusions_arg="${known_fusions}"
+fi
+
 
 # Get FusionInspector Docker image by its ID
 docker load -i /home/dnanexus/in/fi_docker/*.tar.gz
@@ -135,7 +144,7 @@ wd="$(pwd)"
 fusion_ins="docker run -v ${wd}:/data --rm \
        ${DOCKER_IMAGE_ID} \
        FusionInspector \
-       --fusions ${known_fusions},/data/predicted_fusions.txt \
+       --fusions ${fusions_arg} \
        -O /data/temp_out \
        --CPU ${NUMBER_THREADS} \
        --left_fq ${read_1} \


### PR DESCRIPTION
# 12th January 2023: Change information
## Reasons for change
The app failed when passed an empty 'Chimeric.out.junction' STAR-Fusion file. An empty 'Chimeric.out.junction' is expected in the valid cases of: 1) the sample contains no fusions, and 2) the sample has fusions which can only be detected after validation by FusionInspector. The cause of the failure was a line which removes the header row of 'Chimeric.out.junction' and writes the rest of the junction file to a new file. When the junction file only contains a header row, writing the blank output to a new file, failed with permissions errors. 
Example of failed job: https://platform.dnanexus.com/projects/GGzFjGQ43Gg93PY3G5YP177x/monitor/job/GKv4qPj43GgJVx9b25Q7Q83q

## Change made
The header row of the junctions file is no longer removed. Previously it was thought that header-removal was necessary for correct FusionInspector functioning. However, I can't find documentation of why I thought this. On testing without the header-remover code, FI runs normally for samples with full and with empty junction files.

## Testing
Only the 'with_trinity' option was used.

### Run with header-only 'Chimeric.out.junction' file

Please see: job-GKzGP3843Gg1g6b65p861BJz
https://platform.dnanexus.com/projects/GGzFjGQ43Gg93PY3G5YP177x/monitor/job/GKzGP3843Gg1g6b65p861BJz
The expected output was a full set of output files as specified in the app JSON. These were obtained.

### Run with header-and-contents 'Chimeric.out.junction' file

Please see: job-GKzvPq843GgGZYJG7vqV014y
https://platform.dnanexus.com/projects/GGzFjGQ43Gg93PY3G5YP177x/monitor/job/GKzvPq843GgGZYJG7vqV014y
The expected output was a full set of output files as specified in the app JSON. These were obtained.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_fusioninspector/2)
<!-- Reviewable:end -->
