### PR TITLE
Di 1281  Handle empty fusions

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -113,7 +113,7 @@
       "name": "fi_html",
       "label": "fi_html",
       "class": "file",
-      "optional": false,
+      "optional": true,
       "help": "A HTML report of FusionInspector-validated fusions"
     },
     {
@@ -164,7 +164,7 @@
     "aws:eu-central-1": {
       "systemRequirements": {
         "*": {
-          "instanceType": "mem1_ssd1_v2_x4"
+          "instanceType": "mem2_ssd1_v2_x8"
         }
       }
     }

--- a/src/code.sh
+++ b/src/code.sh
@@ -377,7 +377,7 @@ main() {
 
        # if there is fusions predicted. Create a html, else do not create a html as it'll be empty and fail
        number_of_fusions=$(tail -n +2 combined_files/${prefix}.FusionInspector.fusions.abridged.coding_effect.merged.tsv | wc -l)
-       if [ $number_of_fusions >= 1 ]; then
+       if [ $number_of_fusions -ge 1 ]; then
               _create_fusion_inspector_report
        else
               echo "No fusions predicted, so no html report will be outputted"
@@ -410,11 +410,8 @@ main() {
        xargs -I{} mv /home/dnanexus/combined_files/{} /home/dnanexus/out/fi_coding/{}
 
        if [ -f /home/dnanexus/combined_files/${prefix}.fusion_inspector_web.html ]; then
-              echo "html file exists"
               find /home/dnanexus/combined_files -type f -name ${prefix}.fusion_inspector_web.html -printf "%f\n" | \
               xargs -I{} mv /home/dnanexus/combined_files/{} /home/dnanexus/out/fi_html/{}
-       else
-              echo "somalier.groups.tsv does not exist as a single sample was used"
        fi
 
 


### PR DESCRIPTION
- Fix for jobs where html generation fails due to no fusions observed.

Example of a failed job: https://platform.dnanexus.com/panx/projects/Gyy59f84BQB7py52G12Fxqj8/monitor/job/Gz8q1X04BQBG110J3kzFGQv1
Example of a job that passes with this fix: https://platform.dnanexus.com/panx/projects/Gyy59f84BQB7py52G12Fxqj8/monitor/job/GzGq1B84BQBG364px6vGq38j

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_fusioninspector/11)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated configuration settings to allow an optional HTML output and upgraded regional performance specifications for improved service delivery.

- **Bug Fixes**
  - Enhanced the report generation process with conditional checks to ensure that an HTML report is only produced and relocated when valid fusion data is available, thereby preventing empty reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->