### PR TITLE
DI-1281 handle open state files

### DIFF
--- a/src/code.sh
+++ b/src/code.sh
@@ -341,10 +341,10 @@ main() {
        mark-section "Downloading files from subjobs to the parent job"
        mkdir subjob_output
 
-       # wait 60 seconds before trying to download all files as some files
+       # wait 30 seconds before trying to download all files as some files
        # can still be in an open state due to parallel uploading still
        # commencing even after subjobs have completed successful
-       echo "Waiting 60 seconds to ensure all files are hopefully in a closed state"
+       echo "Waiting 30 seconds to ensure all files are hopefully in a closed state"
        sleep 30
 
        for fusion in "${fusion_lists[@]}"; do
@@ -355,7 +355,7 @@ main() {
               sub_job_tars=$(dx find data --json --name $tar_name --path "$DX_WORKSPACE_ID:/FI_outputs" | jq -r '.[].id')
               # check the file state again
               file_state=$(dx describe $sub_job_tars --json | jq -r '.state')
-              if [ $file_state = "open" ]; then
+              if [ "$file_state" = "open" ]; then
                      sleep 30
               fi
               # try to put all subjob_output folder

--- a/src/code.sh
+++ b/src/code.sh
@@ -345,10 +345,9 @@ main() {
        # can still be in an open state due to parallel uploading still
        # commencing even after subjobs have completed successful
        echo "Waiting 60 seconds to ensure all files are hopefully in a closed state"
-       sleep 60
+       sleep 30
 
        for fusion in "${fusion_lists[@]}"; do
-	       echo $fusion
 	       echo ${fusion%.*}
 	       tar_name=$prefix_$fusion.tar
               mkdir subjob_output/inputs_${fusion%.*}
@@ -357,7 +356,7 @@ main() {
               # check the file state again
               file_state=$(dx describe $sub_job_tars --json | jq -r '.state')
               if [ $file_state = "open" ]; then
-                     sleep 60
+                     sleep 30
               fi
               # try to put all subjob_output folder
               echo "$sub_job_tars" | xargs -P $IO_PROCESSES -n1 -I{} sh -c "dx cat $DX_WORKSPACE_ID:{} | tar xf - -C subjob_output/inputs_${fusion%.*}"


### PR DESCRIPTION
Failure in job (https://platform.dnanexus.com/panx/projects/Gyy59f84BQB7py52G12Fxqj8/monitor/job/GzJVF1j4BQB7bqx5b5z41vKK) due to downloading files in an open state. Handle this with a generic sleep 60seconds and a check just before download

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_fusioninspector/12)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the reliability of file downloads by ensuring files are only retrieved after all operations have completed. Users may now see a brief notification indicating that the system is confirming file readiness before proceeding. This improvement helps maintain file integrity during the download process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->