### PR TITLE
DI-281 only merge tsvs

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -112,7 +112,7 @@
     {
       "name": "fi_html",
       "label": "fi_html",
-      "class": "file",
+      "class": "array:file",
       "optional": true,
       "help": "A HTML report of FusionInspector-validated fusions"
     },

--- a/src/code.sh
+++ b/src/code.sh
@@ -321,7 +321,7 @@ main() {
        python3 merge_fusions_tsv.py -a coding_effect_files/*.coding_effect -o temp_output_files
 
        mark-section "Check what fusion contigs were selected from the BAM file"
-       # cat $(find subjob_output -type f -name "*.consolidated.bam.frag_coords") > 
+       
        find subjob_output -name "*.consolidated.bam.frag_coords" -exec cat '{}' + -quit >> temp_output_files/$prefix.consolidated.bam.frag_coords
        cut -f 1 temp_output_files/$prefix.consolidated.bam.frag_coords | sort | uniq > temp_output_files/${prefix}_fusion_contigs_inspected.txt
        # combine all the fusions we wanted to inspect

--- a/src/code.sh
+++ b/src/code.sh
@@ -312,9 +312,8 @@ main() {
        mark-section "Merging fusions tsv files"
        mkdir temp_output_files
 
-       find subjob_output -type f -name "*.FusionInspector.fusions.tsv" -print0 | xargs -0 awk 'NR==1 {header=$_} FNR==1 && NR!=1 { $_ ~ $header getline; } {print}' >> temp_output_files/$prefix.FusionInspector.fusions.tsv
-       find subjob_output -type f -name "*.FusionInspector.fusions.abridged.tsv" -print0 | xargs -0 awk 'NR==1 {header=$_} FNR==1 && NR!=1 { $_ ~ $header getline; } {print}' >> temp_output_files/$prefix.FusionInspector.fusions.abridged.tsv
-
+       find subjob_output -type f -name "*.FusionInspector.fusions.tsv" -print0 | xargs -0 awk '(FNR == 1 && NR != 1) { next } { print }' >> temp_output_files/$prefix.FusionInspector.fusions.tsv
+       find subjob_output -type f -name "*.FusionInspector.fusions.abridged.tsv" -print0 | xargs -0 awk '(FNR == 1 && NR != 1) { next } { print }' >> temp_output_files/$prefix.FusionInspector.fusions.abridged.tsv
        # need to merge all the coding effect files, move to all the coding files to a temporary file
        mkdir coding_effect_files
        find subjob_output -type f -name "*.FusionInspector.fusions.abridged.tsv.coding_effect" -print0 | xargs -0 -I {} mv {} ./coding_effect_files

--- a/src/code.sh
+++ b/src/code.sh
@@ -347,7 +347,7 @@ main() {
        xargs -I{} mv /home/dnanexus/temp_output_files/{} /home/dnanexus/out/fi_coding/{}
 
        find subjob_output -type f -name ${prefix}*.fusion_inspector_web.html | \
-       xargs -I{} mv {} /home/dnanexus/out/fi_html/{}
+       xargs -I{} mv {} /home/dnanexus/out/fi_html/
 
        mark-section "Upload the final outputs"
        time dx-upload-all-outputs --parallel


### PR DESCRIPTION
The script currently tries to merge the files required for the html generation. This proved to take too long so the html will be returned as is at the moment (one html per rescue list).

Example of job that completes: https://platform.dnanexus.com/panx/projects/GxX2YVj44bk8PBQBGb4Qk6f1/monitor/job/J0BK1zQ44bkPKz8J2k3f9XvY

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_fusioninspector/13)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enabled visualisation features in report generation.
- **Bug Fixes**
	- Improved handling of multiple HTML report files as output.
- **Refactor**
	- Simplified the process for consolidating and moving output files.
	- Removed redundant steps in HTML report generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->